### PR TITLE
Output more debugging info on error responses

### DIFF
--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -37,7 +37,11 @@ class JestBuildkiteAnalyticsReporter {
       log('success, yay')
     })
     .catch(function (error) {
-      log('error, failed')
+      if (error.response) {
+        log(`Error, response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+      } else {
+        log(`Error, ${error.message}`)
+      }
     })
 
   }


### PR DESCRIPTION
Adds the response status and test to the debug output, to help people diagnose configuration issues.

For example instead of, the following:

```
error, failed
```

It will now output:

```
Error, response: 401 Unauthorized - {"message":"A test suite could not be found with the supplied API token"}
```